### PR TITLE
Use steady_clock instead of high_resolution_clock

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -107,11 +107,8 @@
 namespace ankerl {
 namespace nanobench {
 
-using Clock = 
-    std::conditional<std::chrono::high_resolution_clock::is_steady, 
-    std::chrono::high_resolution_clock,
-    std::chrono::steady_clock
-    >::type;
+using Clock = std::conditional<std::chrono::high_resolution_clock::is_steady, std::chrono::high_resolution_clock,
+                               std::chrono::steady_clock>::type;
 class Bench;
 struct Config;
 class Result;

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -107,7 +107,7 @@
 namespace ankerl {
 namespace nanobench {
 
-using Clock = std::chrono::high_resolution_clock;
+using Clock = std::chrono::steady_clock;
 class Bench;
 struct Config;
 class Result;

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -107,7 +107,11 @@
 namespace ankerl {
 namespace nanobench {
 
-using Clock = std::chrono::steady_clock;
+using Clock = 
+    std::conditional<std::chrono::high_resolution_clock::is_steady, 
+    std::chrono::high_resolution_clock,
+    std::chrono::steady_clock
+    >::type;
 class Bench;
 struct Config;
 class Result;


### PR DESCRIPTION
`std::high_resolution_clock` is nothing but an alias to either system or steady clock, which means it can differ from one std library implementation to another.
libstdc++ for example will use the realtime clock which is less precise than the monotone clock (steady). An interesting resource about clocks speed and precision is available at https://gitlab.com/chriscox/CppPerformanceBenchmarks/-/wikis/ClockTimeAnalysis .
Howard Hinnant (who wrote the <chrono> scpecification) also says it was a mistake to even standardize it (https://youtu.be/adSAN282YIw?t=4612). 
Google benchmark uses `high_resolution_clock` only if `high_resolution_clock::is_steady()` returns true, otherwise uses `steady_clock`.

Ideally it might be interesting to provide our own clock using clock_gettime, QueryPerformanceCounter directly.
An alternative would be to use rdtsc directly but there are issues with it on some CPUs, and it is x86 only.