### PR TITLE
Remove spaces after semi-colon in csv template

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -700,8 +700,8 @@ inline double d(Clock::duration dur) noexcept {
 namespace templates {
 
 char const* csv() noexcept {
-    return R"DELIM("title"; "name"; "unit"; "batch"; "elapsed"; "error %"; "instructions"; "branches"; "branch misses"; "total"
-{{#result}}"{{title}}"; "{{name}}"; "{{unit}}"; {{batch}}; {{median(elapsed)}}; {{medianAbsolutePercentError(elapsed)}}; {{median(instructions)}}; {{median(branchinstructions)}}; {{median(branchmisses)}}; {{sumProduct(iterations, elapsed)}}
+    return R"DELIM("title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
+{{#result}}"{{title}}";"{{name}}";"{{unit}}";{{batch}};{{median(elapsed)}};{{medianAbsolutePercentError(elapsed)}};{{median(instructions)}};{{median(branchinstructions)}};{{median(branchmisses)}};{{sumProduct(iterations, elapsed)}}
 {{/result}}
 )DELIM";
 }


### PR DESCRIPTION
It seems that having a space after the semi-colon in the csv format can cause issues in some parsers as the CSV [RFC](https://tools.ietf.org/html/rfc4180) seems to imply that any field not starting with a double quote character won't be escaped.
So instead of having the titles being escaped, some parsers would instead include the double quotes as part of the value.
Removing the leading space fixes the issue.