### PR TITLE
Simplify documentation around benchmark comparison

### DIFF
--- a/src/docs/tutorial.rst
+++ b/src/docs/tutorial.rst
@@ -210,8 +210,10 @@ The results are  more stable, with only 0.7% error.
 
 Comparing Results
 =================
+To compare results, keep the `ankerl::nanobench::Bench` object around, enable `.relative(true)`, and `.run(...)` your benchmarks. All benchmarks will be automatically compared to the first one.
 
-I have implemented a comparison of multiple random number generators.
+
+As an example, I have implemented a comparison of multiple random number generators.
 Here several RNGs are compared to a baseline calculated from `std::default_random_engine`.
 I factored out the general benchmarking code so it's easy to use for each of the random number generators:
 


### PR DESCRIPTION
The template example is great for C++ gurus, but it's not intuitive to others just by looking at it on you're supposed to do to get benchmarking comparison to work. 