### PR TITLE
Enable perf counters on older kernels

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -91,7 +91,7 @@
 #define ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS() 0
 #if defined(__linux__) && !defined(ANKERL_NANOBENCH_DISABLE_PERF_COUNTERS)
 #    include <linux/version.h>
-#    if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+#    if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0)
 // PERF_COUNT_HW_REF_CPU_CYCLES only available since kernel 3.3
 // PERF_FLAG_FD_CLOEXEC since kernel 3.14
 #        undef ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS


### PR DESCRIPTION
As stated in the comments and the [manual page](https://man7.org/linux/man-pages/man2/perf_event_open.2.html) , `PERF_COUNT_HW_REF_CPU_CYCLES` is available since linux 3.3.
It tried it locally with an older kernel (3.10) and it works fine.

Can you maybe clarify why the check was done against version 3.14 and not 3.3 ?

Thanks.