### PR TITLE
Add support for custom information per benchmark run

### DIFF
--- a/src/docs/tutorial.rst
+++ b/src/docs/tutorial.rst
@@ -342,6 +342,11 @@ output:
    :language: c++
    :linenos:
 
+Nanobench allows to specify further context information, which may be accessed using ``{{context(name)}}`` where ``name`` names a variable defined in ``Bench::context()``.
+
+.. literalinclude:: ../test/tutorial_context.cpp
+   :language: c++
+   :linenos:
 
 .. _tutorial-template-csv:
 

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -686,12 +686,22 @@ public:
      * Trying to render a variable that hasn't been set before raises an exception.
      * Not included in (default) markdown table.
      *
-     * @see render()
+     * @see clearContext(), render()
      *
      * @param variableName The name of the context variable.
      * @param variableValue The value of the context variable.
      */
     Bench& context(std::string const& variableName, std::string const& variableValue);
+
+    /**
+     * @brief Reset context information.
+     *
+     * This may be improve efficiency when using many context entries,
+     * or improve robustness by removing spurious context entries.
+     *
+     * @see context()
+     */
+    Bench& clearContext();
 
     /**
      * @brief Sets the batch size.
@@ -3147,6 +3157,11 @@ std::string const& Bench::name() const noexcept {
 
 Bench& Bench::context(std::string const& variableName, std::string const& variableValue) {
     mConfig.mContext[variableName] = variableValue;
+    return *this;
+}
+
+Bench& Bench::clearContext() {
+    mConfig.mContext.clear();
     return *this;
 }
 

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -446,6 +446,7 @@ public:
     ANKERL_NANOBENCH(NODISCARD) double sumProduct(Measure m1, Measure m2) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double minimum(Measure m) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double maximum(Measure m) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::string const& context(char const*) const;
     ANKERL_NANOBENCH(NODISCARD) std::string const& context(std::string const&) const;
 
     ANKERL_NANOBENCH(NODISCARD) bool has(Measure m) const noexcept;
@@ -691,6 +692,7 @@ public:
      * @param variableName The name of the context variable.
      * @param variableValue The value of the context variable.
      */
+    Bench& context(char const* variableName, char const* variableValue);
     Bench& context(std::string const& variableName, std::string const& variableValue);
 
     /**
@@ -3024,6 +3026,10 @@ double Result::maximum(Measure m) const noexcept {
     return *std::max_element(data.begin(), data.end());
 }
 
+std::string const& Result::context(char const* variableName) const {
+    return mConfig.mContext.at(variableName);
+}
+
 std::string const& Result::context(std::string const& variableName) const {
     return mConfig.mContext.at(variableName);
 }
@@ -3153,6 +3159,11 @@ Bench& Bench::name(std::string const& benchmarkName) {
 
 std::string const& Bench::name() const noexcept {
     return mConfig.mBenchmarkName;
+}
+
+Bench& Bench::context(char const* variableName, char const* variableValue) {
+    mConfig.mContext[variableName] = variableValue;
+    return *this;
 }
 
 Bench& Bench::context(std::string const& variableName, std::string const& variableValue) {

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -446,7 +446,7 @@ public:
     ANKERL_NANOBENCH(NODISCARD) double sumProduct(Measure m1, Measure m2) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double minimum(Measure m) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double maximum(Measure m) const noexcept;
-    ANKERL_NANOBENCH(NODISCARD) std::string const& context(std::string const&) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::string const& context(std::string const&) const;
 
     ANKERL_NANOBENCH(NODISCARD) bool has(Measure m) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double get(size_t idx, Measure m) const;
@@ -683,7 +683,7 @@ public:
      * @brief Set context information.
      *
      * The information can be accessed using custom render templates via `{{context(variableName)}}`.
-     * Trying to render a variable that hasn't been set before, results in empty output (for that variable).
+     * Trying to render a variable that hasn't been set before raises an exception.
      * Not included in (default) markdown table.
      *
      * @see render()
@@ -3014,14 +3014,8 @@ double Result::maximum(Measure m) const noexcept {
     return *std::max_element(data.begin(), data.end());
 }
 
-std::string const& Result::context(std::string const& variableName) const noexcept {
-    auto context = mConfig.mContext;
-    auto search = context.find(variableName);
-    static std::string NOTFOUND;
-    if (search == context.end()) {
-        return NOTFOUND;
-    }
-    return search->second;
+std::string const& Result::context(std::string const& variableName) const {
+    return mConfig.mContext.at(variableName);
 }
 
 Result::Measure Result::fromString(std::string const& str) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources_local(nb PRIVATE
     example_shuffle.cpp
     tutorial_complexity_set.cpp
     tutorial_complexity_sort.cpp
+    tutorial_context.cpp
     tutorial_fast_v1.cpp
     tutorial_fast_v2.cpp
     tutorial_fluctuating_v1.cpp

--- a/src/test/tutorial_context.cpp
+++ b/src/test/tutorial_context.cpp
@@ -42,4 +42,13 @@ TEST_CASE("tutorial_context") {
         .run("+=", plus_eq<double>)
         .run("fma", fma<double>);
     bench.render(csv(), std::cout);
+    // Changing the title resets the results, but not the context:
+    bench.title("New Title");
+    bench.run("+=", plus_eq<float>);
+    bench.render(csv(), std::cout);
+    CHECK_EQ(bench.results().front().context("foo"), "baz"); // != bar
+    // The context has to be reset manually, which causes render to fail:
+    bench.title("Yet Another Title").clearContext();
+    bench.run("+=", plus_eq<float>);
+    CHECK_THROWS(bench.render(csv(), std::cout));
 }

--- a/src/test/tutorial_context.cpp
+++ b/src/test/tutorial_context.cpp
@@ -1,0 +1,50 @@
+#include <nanobench.h>
+#include <thirdparty/doctest/doctest.h>
+
+#include <iostream>
+#include <cmath>
+
+namespace {
+
+template<typename T>
+void fma() {
+    T x(1), y(2), z(3);
+    z = std::fma(x, y, z);
+    ankerl::nanobench::doNotOptimizeAway(z);
+}
+
+template<typename T>
+void plus_eq() {
+    T x(1), y(2), z(3);
+    z += x*y;
+    ankerl::nanobench::doNotOptimizeAway(z);
+}
+
+char const* csv() {
+    return R"DELIM("title";"name";"scalar";"foo";"elapsed";"total"
+{{#result}}"{{title}}";"{{name}}";"{{context(scalar)}}";"{{context(foo)}}";{{median(elapsed)}};{{sumProduct(iterations, elapsed)}}
+{{/result}})DELIM";
+}
+
+} // namespace
+
+TEST_CASE("tutorial_context") {
+    ankerl::nanobench::Bench bench;
+    bench.title("Addition").output(nullptr);
+    bench.run("missing context", [] {
+        int a = 1, b = 2;
+        int c = a + b;
+        ankerl::nanobench::doNotOptimizeAway(c);
+    });
+    bench
+        .context("scalar", "f32")
+        .context("foo", "bar")
+        .run("+=", plus_eq<float>)
+        .run("fma", fma<float>);
+    bench
+        .context("scalar", "f64")
+        .context("foo", "baz")
+        .run("+=", plus_eq<double>)
+        .run("fma", fma<double>);
+    bench.render(csv(), std::cout);
+}

--- a/src/test/tutorial_context.cpp
+++ b/src/test/tutorial_context.cpp
@@ -31,11 +31,6 @@ char const* csv() {
 TEST_CASE("tutorial_context") {
     ankerl::nanobench::Bench bench;
     bench.title("Addition").output(nullptr);
-    bench.run("missing context", [] {
-        int a = 1, b = 2;
-        int c = a + b;
-        ankerl::nanobench::doNotOptimizeAway(c);
-    });
     bench
         .context("scalar", "f32")
         .context("foo", "bar")


### PR DESCRIPTION
* Set via `bench.context("name", "value")`
* Render/access via `{{context(name)}}`
* Rendering variables without a value ~~produce empty output (for that variable)~~ throws an exception
* Values persist to subsequent calls to `Bench::run`; my use case assumes that all variables are needed for all runs
* Reset via `bench.clearContext()`

Unfortunately, I haven't been able to build and therefore check the docs I wrote.

Also, I saw that some methods are overloaded for `char const*` and `std::string const&`. Should `Bench::context` do the same? What about `Result::context`?

Do you think `context` is a feasible name? If not, how should these methods be called?