### PR TITLE
fix compilation error on msvc < 1928

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -405,7 +405,11 @@ struct Config {
     Config& operator=(Config const&);
     Config& operator=(Config&&);
     Config(Config const&);
+#if defined(_MSC_VER) && _MSC_VER < 1928
+    Config(Config&&);
+#else
     Config(Config&&) noexcept;
+#endif
 };
 ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 
@@ -2854,7 +2858,11 @@ Config::~Config() = default;
 Config& Config::operator=(Config const&) = default;
 Config& Config::operator=(Config&&) = default;
 Config::Config(Config const&) = default;
+#if defined(_MSC_VER) && _MSC_VER < 1928
+Config::Config(Config&&) = default;
+#else
 Config::Config(Config&&) noexcept = default;
+#endif
 
 // provide implementation here so it's only generated once
 Result::~Result() = default;

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -435,7 +435,11 @@ public:
     Result& operator=(Result const&);
     Result& operator=(Result&&);
     Result(Result const&);
+#if defined(_MSC_VER) && _MSC_VER < 1928
+    Result(Result&&);
+#else
     Result(Result&&) noexcept;
+#endif
 
     // adds new measurement results
     // all values are scaled by iters (except iters...)
@@ -2869,7 +2873,11 @@ Result::~Result() = default;
 Result& Result::operator=(Result const&) = default;
 Result& Result::operator=(Result&&) = default;
 Result::Result(Result const&) = default;
+#if defined(_MSC_VER) && _MSC_VER < 1928
+Result::Result(Result&&) = default;
+#else
 Result::Result(Result&&) noexcept = default;
+#endif
 
 namespace detail {
 template <typename T>


### PR DESCRIPTION
Hi.
I met compilation errors on msvc 1927.
https://godbolt.org/z/9Ph4v674E

```
error C2610: 'ankerl::nanobench::Config::Config(ankerl::nanobench::Config &&) noexcept': 
is not a special member function or comparison operator which can be defaulted
```

It was caused by adding STL containers member to `Config` and `Result` since nanobench 7.3.8, because STL containers in msvc < 1928 seem not to have noexcept move constructor.

Simple reproduce code is following:
https://godbolt.org/z/5YM7bMTrW

It works fine on msvc 1928.
https://godbolt.org/z/YdThcWh3E

Please review my PR and merge it if possible.
It works fine on msvc 1927.
https://godbolt.org/z/K7TPhYzj8
