### PR TITLE
Workaround missing `noexcept` for std::string move assignment

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -120,6 +120,10 @@
 #    define ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
 #endif
 
+// noexcept may be missing for std::string.
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58265
+#define ANKERL_NANOBENCH_PRIVATE_NOEXCEPT_STRING_MOVE() std::is_nothrow_move_assignable<std::string>::value
+
 // declarations ///////////////////////////////////////////////////////////////////////////////////
 
 namespace ankerl {
@@ -404,7 +408,7 @@ struct Config {
     Config();
     ~Config();
     Config& operator=(Config const& other);
-    Config& operator=(Config&& other) noexcept;
+    Config& operator=(Config&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
     Config(Config const& other);
     Config(Config&& other) noexcept;
 };
@@ -430,7 +434,7 @@ public:
 
     ~Result();
     Result& operator=(Result const& other);
-    Result& operator=(Result&& other) noexcept;
+    Result& operator=(Result&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
     Result(Result const& other);
     Result(Result&& other) noexcept;
 
@@ -628,7 +632,7 @@ public:
     Bench();
 
     Bench(Bench&& other) noexcept;
-    Bench& operator=(Bench&& other) noexcept;
+    Bench& operator=(Bench&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
     Bench(Bench const& other);
     Bench& operator=(Bench const& other);
     ~Bench() noexcept;
@@ -2895,14 +2899,14 @@ std::ostream& operator<<(std::ostream& os, MarkDownCode const& mdCode) {
 Config::Config() = default;
 Config::~Config() = default;
 Config& Config::operator=(Config const&) = default;
-Config& Config::operator=(Config&&) noexcept = default;
+Config& Config::operator=(Config&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
 Config::Config(Config const&) = default;
 Config::Config(Config&&) noexcept = default;
 
 // provide implementation here so it's only generated once
 Result::~Result() = default;
 Result& Result::operator=(Result const&) = default;
-Result& Result::operator=(Result&&) noexcept = default;
+Result& Result::operator=(Result&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
 Result::Result(Result const&) = default;
 Result::Result(Result&&) noexcept = default;
 
@@ -3117,7 +3121,7 @@ Bench::Bench() {
 }
 
 Bench::Bench(Bench&&) noexcept = default;
-Bench& Bench::operator=(Bench&&) noexcept = default;
+Bench& Bench::operator=(Bench&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
 Bench::Bench(Bench const&) = default;
 Bench& Bench::operator=(Bench const&) = default;
 Bench::~Bench() noexcept = default;


### PR DESCRIPTION
Due to GCC/libstdc++ bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58265 the string move assignment may be missing `noexcept`, resulting in build errors even with relative recent GCC versions:

```
nanobench.h:2898:9: error: function 'ankerl::nanobench::Config& ankerl::nanobench::Config::operator=(ankerl::nanobench::Config&&)' defaulted on its redeclaration with an exception-specification that differs from the implicit exception-specification ''
 Config& Config::operator=(Config&&) noexcept = default;
         ^~~~~~
```

Hit this with some GCC 7.5.0 based cross toolchain, and for me it's locally reproducible (in Ubuntu) with `g++-8 -D_GLIBCXX_USE_CXX11_ABI=0 ...`