### PR TITLE
Conventional install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,7 @@ if (NANOBENCH_STANDALONE_PROJECT)
 
 
     include(GNUInstallDirs)
-    set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake)
-    set(INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
+    set(NB_INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
     # Install library target
     add_library(nanobench STATIC ${PROJECT_SOURCE_DIR}/src/test/app/nanobench.cpp)
@@ -98,8 +97,6 @@ if (NANOBENCH_STANDALONE_PROJECT)
     install(
       TARGETS nanobench
       EXPORT install_targets
-      LIBRARY DESTINATION ${INSTALL_LIBDIR}
-      ARCHIVE DESTINATION ${INSTALL_LIBDIR}
     )
 
     # Install targets file


### PR DESCRIPTION
- CMake config files are typically installed under `${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}`, not the other way around;
- `LIBRARY DESTINATION` and `ARCHIVE_DESTINATION` should default to `CMAKE_INSTALL_LIBDIR` (not `CMAKE_INSTALL_LIBDIR/nanobench`), which is the default when omited.