### PR TITLE
Add overloads supporting `std::string_view`

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -46,6 +46,11 @@
 #include <unordered_map> // holds context information of results
 #include <vector>        // holds all results
 
+#if __cplusplus >= 201606L
+#    include <string_view> // some names
+#    define ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW __cpp_lib_string_view
+#endif // __cplusplus >= 201606L
+
 #define ANKERL_NANOBENCH(x) ANKERL_NANOBENCH_PRIVATE_##x()
 
 #define ANKERL_NANOBENCH_PRIVATE_CXX() __cplusplus
@@ -663,6 +668,12 @@ public:
     ANKERL_NANOBENCH(NOINLINE)
     Bench& run(std::string const& benchmarkName, Op&& op);
 
+#ifdef ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
+    template <typename Op>
+    ANKERL_NANOBENCH(NOINLINE)
+    Bench& run(std::string_view benchmarkName, Op&& op);
+#endif // ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
+
     /**
      * @brief Same as run(char const* benchmarkName, Op op), but instead uses the previously set name.
      * @tparam Op The code to benchmark.
@@ -687,6 +698,9 @@ public:
     /// Name of the benchmark, will be shown in the table row.
     Bench& name(char const* benchmarkName);
     Bench& name(std::string const& benchmarkName);
+#ifdef ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
+    Bench& name(std::string_view benchmarkName);
+#endif // ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
     ANKERL_NANOBENCH(NODISCARD) std::string const& name() const noexcept;
 
     /**
@@ -1241,6 +1255,14 @@ Bench& Bench::run(std::string const& benchmarkName, Op&& op) {
     name(benchmarkName);
     return run(std::forward<Op>(op));
 }
+
+#ifdef ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
+template <typename Op>
+Bench& Bench::run(std::string_view benchmarkName, Op&& op) {
+    name(benchmarkName);
+    return run(std::forward<Op>(op));
+}
+#endif // ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
 
 template <typename Op>
 BigO Bench::complexityBigO(char const* benchmarkName, Op op) const {
@@ -3213,6 +3235,13 @@ Bench& Bench::name(std::string const& benchmarkName) {
     mConfig.mBenchmarkName = benchmarkName;
     return *this;
 }
+
+#    ifdef ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
+Bench& Bench::name(std::string_view const benchmarkName) {
+    mConfig.mBenchmarkName = benchmarkName;
+    return *this;
+}
+#    endif // ANKERL_NANOBENCH_PRIVATE_UTILIZE_STRING_VIEW
 
 std::string const& Bench::name() const noexcept {
     return mConfig.mBenchmarkName;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,11 +25,12 @@ target_sources_local(nb PRIVATE
     tutorial_fluctuating_v1.cpp
     tutorial_fluctuating_v2.cpp
     tutorial_mustache.cpp
-    tutorial_render_simple.cpp    
+    tutorial_render_simple.cpp
     tutorial_slow_v1.cpp
     tutorial_slow_v2.cpp
     unit_api.cpp
     unit_cold.cpp
+    unit_cpp17_api.cpp
     unit_exact_iters_and_epochs.cpp
     unit_romutrio.cpp
     unit_templates.cpp

--- a/src/test/unit_cpp17_api.cpp
+++ b/src/test/unit_cpp17_api.cpp
@@ -1,0 +1,45 @@
+#include <nanobench.h>
+#include <thirdparty/doctest/doctest.h>
+
+#if __cplusplus < 201606L // __cpp_lib_string_view
+
+TEST_CASE("Placeholder case for C++17") {
+    INFO("C++17 tests skiped");
+}
+
+#else
+
+#    include <string_view>
+
+#    ifdef _MSC_VER
+// Compiler known issue
+// warning C4455: 'operator ""sv': literal suffix identifiers that do not start
+// with an underscore are reserved
+#        pragma warning(push)
+#        pragma warning(disable : 4455)
+#    endif
+using std::string_view_literals::operator""sv;
+#    ifdef _MSC_VER
+#        pragma warning(pop)
+#    endif
+
+TEST_CASE("Set and change name from string_view") {
+    ankerl::nanobench::Bench bench;
+    bench.name("string view 1"sv).run([] {
+        std::vector<int> const v{{11, 5, 5, 5, 5, 5, 5, 5}};
+    });
+
+    bench.name("string view 2"sv);
+    bench.run([] {
+        std::vector<int> const v{{11, 5, 5, 5, 5, 5, 5, 5}};
+    });
+}
+
+TEST_CASE("Set name from string_view") {
+    ankerl::nanobench::Bench bench;
+    bench.run("string view 3"sv, [] {
+        std::vector<int> const v{{11, 5, 5, 5, 5, 5, 5, 5}};
+    });
+}
+
+#endif // __cplusplus < 201606L


### PR DESCRIPTION
Support C++17 `std::string_view` in

```
Bench& Bench::name(std::string_view benchmarkName)
Bench& Bench::run(std::string_view benchmarkName, Op&& op)
```