### PR TITLE
Feat/multi output

### DIFF
--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -1307,6 +1307,7 @@ void doNotOptimizeAway(T const& val) {
 #    include <fstream>   // ifstream to parse proc files
 #    include <iomanip>   // setw, setprecision
 #    include <iostream>  // cout
+#    include <mutex>     // mutex, lock_guard
 #    include <numeric>   // accumulate
 #    include <random>    // random_device
 #    include <sstream>   // to_s in Number
@@ -2105,7 +2106,10 @@ void printStabilityInformationOnce(std::ostream* outStream) {
 
 // remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
 uint64_t& singletonHeaderHash(std::ostream const& _out) noexcept {
+    static std::mutex sMutex;
     static std::unordered_map<std::ostream const*, uint64_t> sHeaderHashes;
+    std::lock_guard<std::mutex> guard{sMutex};
+
     return sHeaderHashes[&_out];
 }
 

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -1791,7 +1791,7 @@ void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<
 void printStabilityInformationOnce(std::ostream* outStream);
 
 // remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
-uint64_t& singletonHeaderHash() noexcept;
+uint64_t& singletonHeaderHash(std::ostream const& _out) noexcept;
 
 // determines resolution of the given clock. This is done by measuring multiple times and returning the minimum time difference.
 Clock::duration calcClockResolution(size_t numEvaluations) noexcept;
@@ -2104,9 +2104,9 @@ void printStabilityInformationOnce(std::ostream* outStream) {
 }
 
 // remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
-uint64_t& singletonHeaderHash() noexcept {
-    static uint64_t sHeaderHash{};
-    return sHeaderHash;
+uint64_t& singletonHeaderHash(std::ostream const& _out) noexcept {
+    static std::unordered_map<std::ostream const*, uint64_t> sHeaderHashes;
+    return sHeaderHashes[&_out];
 }
 
 ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
@@ -2332,8 +2332,8 @@ struct IterationLogic::Impl {
             hash = hash_combine(std::hash<bool>{}(mBench.relative()), hash);
             hash = hash_combine(std::hash<bool>{}(mBench.performanceCounters()), hash);
 
-            if (hash != singletonHeaderHash()) {
-                singletonHeaderHash() = hash;
+            if (hash != singletonHeaderHash(os)) {
+                singletonHeaderHash(os) = hash;
 
                 // no result yet, print header
                 os << std::endl;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,12 +25,13 @@ target_sources_local(nb PRIVATE
     tutorial_fluctuating_v1.cpp
     tutorial_fluctuating_v2.cpp
     tutorial_mustache.cpp
-    tutorial_render_simple.cpp    
+    tutorial_render_simple.cpp
     tutorial_slow_v1.cpp
     tutorial_slow_v2.cpp
     unit_api.cpp
     unit_cold.cpp
     unit_exact_iters_and_epochs.cpp
+    unit_multi_bench.cpp
     unit_romutrio.cpp
     unit_templates.cpp
     unit_timeunit.cpp

--- a/src/test/unit_multi_bench.cpp
+++ b/src/test/unit_multi_bench.cpp
@@ -1,0 +1,67 @@
+#include <nanobench.h>
+#include <thirdparty/doctest/doctest.h>
+
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <unordered_map>
+
+
+
+template <typename Container>
+static void runTest(std::string container_name, ankerl::nanobench::Bench& bench_at, ankerl::nanobench::Bench& bench_operator) {
+    size_t const maxSize = 1000000;
+
+    ankerl::nanobench::Rng rng;
+
+    Container container;
+    for (size_t i{0}; i < maxSize; ++i) {
+        auto value = uint8_t(rng.bounded(256));
+        container[i] = value;
+    }
+    bench_at.run(container_name, [&] {
+        ankerl::nanobench::doNotOptimizeAway(container.at(rng.bounded(maxSize)));
+    });
+    bench_operator.run(container_name, [&] {
+        ankerl::nanobench::doNotOptimizeAway(container[rng.bounded(maxSize)]);
+    });
+}
+
+// NOLINTNEXTLINE
+TEST_CASE("multi_bench") {
+    // Suppress any stability warnings for later outputs
+    ankerl::nanobench::Bench().run("suppress_warning", []{});
+
+    ankerl::nanobench::Bench bench_at;
+    std::stringstream output_at;
+    bench_at
+        .title("at()")
+        .output(&output_at);
+
+    ankerl::nanobench::Bench bench_operator;
+    std::stringstream output_operator;
+    bench_operator
+        .title("operator[]")
+        .output(&output_operator);
+
+
+    runTest<std::map<size_t, uint8_t> >("std::map", bench_at, bench_operator);
+    runTest<std::unordered_map<size_t, uint8_t> >("std::unordered_map", bench_at, bench_operator);
+
+    size_t linect_at{};
+    size_t linect_operator{};
+    {
+        std::string s;
+        while(std::getline(output_at, s)) {
+            linect_at += 1;
+        }
+        while(std::getline(output_operator, s)) {
+            linect_operator += 1;
+        }
+    }
+    CHECK(linect_at == 5);
+    CHECK(linect_operator == 5);
+
+    std::cout << output_at.str() << '\n'
+              << output_operator.str() << '\n';
+}


### PR DESCRIPTION
This allows to use multiple 'Bench' classes to group benchmarks together.
Only print a new header if the same output stream runs a new test.

This changes the output:

```
|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | at()      
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:-----                                                                                                                                                                              
|            1,280.29 |          781,073.04 |   12.2% |        2,285.81 |        5,338.52 |  0.428 |         424.05 |    2.5% |      0.01 | :wavy_dash: `std::map` (Unstable with ~647.3 iters. Increase `minEpochIterations` to e.g. 6473)
                                                                                                                                                               
|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | operator[]
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:-----------
|            1,333.55 |          749,878.68 |    8.0% |        2,285.69 |        5,357.32 |  0.427 |         423.92 |    2.5% |      0.01 | :wavy_dash: `std::map` (Unstable with ~765.7 iters. Increase `minEpochIterations` to e.g. 7657)
                                                                                                                                                                                                                                                                                                                               
|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | at()
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:-----
|              208.09 |        4,805,636.97 |    1.9% |          536.00 |          919.61 |  0.583 |          89.00 |    0.0% |      0.01 | `std::unordered_map`
                                                                               
|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | operator[]
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:-----------
|              250.45 |        3,992,816.28 |    5.9% |          466.00 |        1,103.79 |  0.422 |          76.00 |    0.0% |      0.01 | :wavy_dash: `std::unordered_map` (Unstable with ~4,042.5 iters. Increase `minEpochIterations` to e.g. 40425)
```

to

```
|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | at()
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:-----
|            1,262.44 |          792,117.10 |   15.0% |        2,284.03 |        4,821.46 |  0.474 |         423.68 |    2.5% |      0.01 | :wavy_dash: `std::map` (Unstable with ~656.7 iters. Increase `minEpochIterations` to e.g. 6567)
|              210.86 |        4,742,583.39 |    1.1% |          536.00 |          925.75 |  0.579 |          89.00 |    0.0% |      0.01 | `std::unordered_map`


|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | operator[]
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:-----------
|            1,036.34 |          964,935.25 |    0.5% |        2,285.09 |        4,640.47 |  0.492 |         423.85 |    2.5% |      0.01 | `std::map`
|              197.68 |        5,058,664.21 |    1.0% |          466.00 |          878.61 |  0.530 |          76.00 |    0.0% |      0.01 | `std::unordered_map`
```

More details on the intended use can be seen in `src/test/unit_multi_bench.cpp` 