### PR TITLE
Feature: monitor cache-related perf events for L1D & LLC accesses/misses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.25)
 project(nanobench LANGUAGES CXX)
 
 # determine whether this is a standalone project or included by other projects

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -2326,7 +2326,7 @@ struct IterationLogic::Impl {
                     if (rBraMedian >= 1e-9) {
                         p = 100.0 * mResult.median(Result::Measure::branchmisses) / rBraMedian;
                     }
-                    columns.emplace_back(10, 1, "miss%", "%", p);
+                    columns.emplace_back(13, 1, "bra miss%", "%", p);
                 }
             }
             if (mBench.performanceCounters() && mResult.has(Result::Measure::l1daccesses)) {

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -1478,9 +1478,9 @@ char const* json() noexcept {
                     "contextswitches": {{contextswitches}},
                     "instructions": {{instructions}},
                     "branchinstructions": {{branchinstructions}},
-                    "branchmisses": {{branchmisses}}
+                    "branchmisses": {{branchmisses}},
                     "l1daccesses": {{l1daccesses}},
-                    "l1dmisses": {{l1dmisses}}
+                    "l1dmisses": {{l1dmisses}},
                     "llcaccesses": {{llcaccesses}},
                     "llcmisses": {{llcmisses}}
                 }{{^-last}},{{/-last}}

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -1464,6 +1464,10 @@ char const* json() noexcept {
             "median(pagefaults)": {{median(pagefaults)}},
             "median(branchinstructions)": {{median(branchinstructions)}},
             "median(branchmisses)": {{median(branchmisses)}},
+            "median(l1daccesses)": {{median(l1daccesses)}},
+            "median(l1dmisses)": {{median(l1dmisses)}},
+            "median(llcaccesses)": {{median(llcaccesses)}},
+            "median(llcmisses)": {{median(llcmisses)}},
             "totalTime": {{sumProduct(iterations, elapsed)}},
             "measurements": [
 {{#measurement}}                {

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -1382,7 +1382,7 @@ namespace templates {
 
 char const* csv() noexcept {
     return R"DELIM("title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
-{{#result}}"{{title}}";"{{name}}";"{{unit}}";{{batch}};{{median(elapsed)}};{{medianAbsolutePercentError(elapsed)}};{{median(instructions)}};{{median(branchinstructions)}};{{median(branchmisses)}};{{sumProduct(iterations, elapsed)}}
+{{#result}}"{{title}}";"{{name}}";"{{unit}}";{{batch}};{{median(elapsed)}};{{medianAbsolutePercentError(elapsed)}};{{median(instructions)}};{{median(branchinstructions)}};{{median(branchmisses)}};{{median(l1daccesses)}};{{median(l1dmisses)}};{{median(llcaccesses)}};{{median(llcmisses)}};{{sumProduct(iterations, elapsed)}}
 {{/result}})DELIM";
 }
 
@@ -1475,6 +1475,10 @@ char const* json() noexcept {
                     "instructions": {{instructions}},
                     "branchinstructions": {{branchinstructions}},
                     "branchmisses": {{branchmisses}}
+                    "l1daccesses": {{l1daccesses}},
+                    "l1dmisses": {{l1dmisses}}
+                    "llcaccesses": {{llcaccesses}},
+                    "llcmisses": {{llcmisses}}
                 }{{^-last}},{{/-last}}
 {{/measurement}}            ]
         }{{^-last}},{{/-last}}

--- a/src/include/nanobench.h
+++ b/src/include/nanobench.h
@@ -1381,8 +1381,8 @@ inline Clock::duration clockResolution() noexcept;
 namespace templates {
 
 char const* csv() noexcept {
-    return R"DELIM("title";"name";"unit";"batch";"elapsed";"error %";"instructions";"branches";"branch misses";"total"
-{{#result}}"{{title}}";"{{name}}";"{{unit}}";{{batch}};{{median(elapsed)}};{{medianAbsolutePercentError(elapsed)}};{{median(instructions)}};{{median(branchinstructions)}};{{median(branchmisses)}};{{median(l1daccesses)}};{{median(l1dmisses)}};{{median(llcaccesses)}};{{median(llcmisses)}};{{sumProduct(iterations, elapsed)}}
+    return R"DELIM(title,name,unit,batch,elapsed,error %,instructions,branches,branch misses,total
+{{#result}}{{title}},{{name}},{{unit}},{{batch}},{{median(elapsed)}},{{medianAbsolutePercentError(elapsed)}},{{median(instructions)}},{{median(branchinstructions)}},{{median(branchmisses)}},{{median(l1daccesses)}},{{median(l1dmisses)}},{{median(llcaccesses)}},{{median(llcmisses)}},{{sumProduct(iterations, elapsed)}}
 {{/result}})DELIM";
 }
 


### PR DESCRIPTION
This PR adds support for monitoring L1D and LLC cache accesses & misses using Linux perf events.

Changelog:
- added cache events to the `PerfCountSet` and `Measure` data types;
- added cache events to the list of monitored hardware counters in the `PerformanceCounters` ctor:
  - needed to use the private `monitor` method because cache events require special configuration and would fail to compile due to `-Wconversion` and `-Werror` being enabled.
- added cache events to the benchmark's output;
- added cache events to the Mustache-like templates;
- changed `miss%` column to `bra miss%` for the sake of explicitness.

Sample output of this new feature:
```
| relative |                s/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |  bra miss% |     L1D$ ref/op | L1D$ miss% |      LL$ ref/op |  LL$ miss% |     total | serial
|---------:|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|-----------:|----------------:|-----------:|----------------:|-----------:|----------:|:-------
|   100.0% |                0.24 |                4.12 |    0.3% |  439,623,472.00 |  585,519,984.00 |  0.751 |  17,564,921.00 |       1.5% |  268,438,282.00 |     50.24% |  119,018,261.00 |      0.02% |      2.69 | `GEMM w/ standard layout`
|   169.8% |                0.14 |                7.00 |    0.3% |2,086,674,645.00 |  344,725,668.00 |  6.053 |  67,896,469.00 |       0.4% |  269,224,102.00 |     67.12% |    3,846,202.00 |      0.06% |      1.57 | `GEMM w/ tiled layout`
```
Rendered as:
| relative |                s/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |  bra miss% |     L1D$ ref/op | L1D$ miss% |      LL$ ref/op |  LL$ miss% |     total | serial
|---------:|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|-----------:|----------------:|-----------:|----------------:|-----------:|----------:|:-------
|   100.0% |                0.24 |                4.12 |    0.3% |  439,623,472.00 |  585,519,984.00 |  0.751 |  17,564,921.00 |       1.5% |  268,438,282.00 |     50.24% |  119,018,261.00 |      0.02% |      2.69 | `GEMM w/ standard layout`
|   169.8% |                0.14 |                7.00 |    0.3% |2,086,674,645.00 |  344,725,668.00 |  6.053 |  67,896,469.00 |       0.4% |  269,224,102.00 |     67.12% |    3,846,202.00 |      0.06% |      1.57 | `GEMM w/ tiled layout`

