### PR TITLE
docs: Add missing define directive to fix examples

### DIFF
--- a/src/docs/code/full_example.cpp
+++ b/src/docs/code/full_example.cpp
@@ -1,3 +1,4 @@
+#define ANKERL_NANOBENCH_IMPLEMENT
 #include <nanobench.h>
 
 #include <atomic>


### PR DESCRIPTION
This PR adds a missing define directive in the example in the docs, without which the code will not compile.